### PR TITLE
Add SIGHUP alternative and additional agent annotations

### DIFF
--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -1,8 +1,9 @@
 minikube:
+	minikube config set vm-driver virtualbox
 	minikube start
 
 setup:
-	eval $(minikube docker-env)
+	eval $(minikube -p minikube docker-env)
 	cd ../payments-database && docker build -t payments-database .
 	cd ../payments-processor && docker build -t payments-processor .
 	helm upgrade --install vault hashicorp/vault -f helm/vault.yaml
@@ -14,9 +15,10 @@ setup:
 	bash scripts/setup.sh
 
 java:
-	eval $(minikube docker-env)
+	eval $(minikube -p minikube docker-env)
 	cd ../payments-app/java && docker build -t payments-app:java .
-	kubectl apply -f applications/payments-app.yaml
+	# kubectl apply -f applications/payments-app.yaml
+	kubectl apply -f applications/payments-app-sighup.yaml
 	kubectl rollout status deployment/payments-app
 
 clean:

--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -17,8 +17,8 @@ setup:
 java:
 	eval $(minikube -p minikube docker-env)
 	cd ../payments-app/java && docker build -t payments-app:java .
-	# kubectl apply -f applications/payments-app.yaml
-	kubectl apply -f applications/payments-app-sighup.yaml
+	kubectl apply -f applications/payments-app.yaml
+	# kubectl apply -f applications/payments-app-sighup.yaml
 	kubectl rollout status deployment/payments-app
 
 clean:

--- a/kubernetes/applications/payments-app-sighup.yaml
+++ b/kubernetes/applications/payments-app-sighup.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payments-app
+  labels:
+    app: payments-app
+spec:
+  type: NodePort
+  ports:
+    - port: 8081
+      targetPort: 8081
+      nodePort: 30081
+  selector:
+    app: payments-app
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: payments-app
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: payments-app
+  annotations:
+    kubernetes.io/service-account.name: "payments-app"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: payments-app
+      app: payments-app
+  template:
+    metadata:
+      labels:
+        service: payments-app
+        app: payments-app
+      annotations:
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/role: "payments-app"
+        vault.hashicorp.com/agent-inject-token: "true"
+        vault.hashicorp.com/agent-run-as-same-user: "true"
+        vault.hashicorp.com/agent-cache-enable: "true"
+        vault.hashicorp.com/template-static-secret-render-interval: "10m"
+
+        vault.hashicorp.com/agent-inject-secret-processor: "payments/secrets/data/processor"
+        vault.hashicorp.com/secret-volume-path-processor: "/vault/secrets/config/processor"
+        vault.hashicorp.com/agent-inject-file-processor: "payments-app.properties"
+        vault.hashicorp.com/agent-inject-template-processor: |
+          payment.processor.url=http://payments-processor:8080
+          {{- with secret "payments/secrets/processor" }}
+          payment.processor.username={{ .Data.data.username }}
+          payment.processor.password={{ .Data.data.password }}
+          {{- end }}
+        vault.hashicorp.com/agent-inject-command-processor: |
+          kill -HUP $(pidof java)
+
+        vault.hashicorp.com/agent-inject-secret-database: "payments/database/creds/payments-app"
+        vault.hashicorp.com/secret-volume-path-database: "/vault/secrets/config/database"
+        vault.hashicorp.com/agent-inject-file-database: "payments-app.properties"
+        vault.hashicorp.com/agent-inject-template-database: |
+          payments.db.url=jdbc:postgresql://payments-database:5432/payments
+          {{- with secret "payments/database/creds/payments-app" }}
+          payments.db.username={{ .Data.username }}
+          payments.db.password={{ .Data.password }}
+          {{- end }}
+        vault.hashicorp.com/agent-inject-command-database: |
+          kill -HUP $(pidof java)
+
+    spec:
+      serviceAccountName: payments-app
+      shareProcessNamespace: true
+      containers:
+        - name: payments-app
+          image: payments-app:java
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8081
+          command: ["/bin/sh"]
+          args: ["-c", "java -XX:+UseContainerSupport -Dspring.cloud.config.server.vault.token=$(cat /vault/secrets/token) -Dspring.cloud.vault.token=$(cat /vault/secrets/token) -Djava.security.egd=file:/dev/./urandom -jar /app/spring-boot-application.jar"]
+          env:
+            - name: VAULT_HOST
+              value: vault
+            - name: CONFIG_HOME
+              value: /vault/secrets
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8081
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+            periodSeconds: 10
+            failureThreshold: 30
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 3000

--- a/kubernetes/applications/payments-app.yaml
+++ b/kubernetes/applications/payments-app.yaml
@@ -46,6 +46,8 @@ spec:
         vault.hashicorp.com/agent-inject: "true"
         vault.hashicorp.com/role: "payments-app"
         vault.hashicorp.com/agent-inject-token: "true"
+        vault.hashicorp.com/agent-cache-enable: "true"
+        vault.hashicorp.com/template-static-secret-render-interval: "10m"
 
         vault.hashicorp.com/agent-inject-secret-processor: "payments/secrets/data/processor"
         vault.hashicorp.com/secret-volume-path-processor: "/vault/secrets/config/processor"
@@ -57,7 +59,7 @@ spec:
           payment.processor.password={{ .Data.data.password }}
           {{- end }}
         vault.hashicorp.com/agent-inject-command-processor: |
-          wget -qO- --header='Content-Type:application/json' --post-data='{}' http://127.0.0.1:8081/actuator/refresh || true
+          wget -qO- --header='Content-Type:application/json' --post-data='{}' http://127.0.0.1:8081/actuator/refresh
 
         vault.hashicorp.com/agent-inject-secret-database: "payments/database/creds/payments-app"
         vault.hashicorp.com/secret-volume-path-database: "/vault/secrets/config/database"
@@ -69,7 +71,7 @@ spec:
           payments.db.password={{ .Data.password }}
           {{- end }}
         vault.hashicorp.com/agent-inject-command-database: |
-          wget -qO- --header='Content-Type:application/json' --post-data='{}' http://127.0.0.1:8081/actuator/refresh || true
+          wget -qO- --header='Content-Type:application/json' --post-data='{}' http://127.0.0.1:8081/actuator/refresh
 
     spec:
       serviceAccountName: payments-app

--- a/kubernetes/scripts/setup.sh
+++ b/kubernetes/scripts/setup.sh
@@ -27,7 +27,7 @@ vault write payments/database/roles/payments-app \
     creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; \
 		GRANT ALL PRIVILEGES ON payments TO \"{{name}}\";" \
     default_ttl="2m" \
-    max_ttl="15m"
+    max_ttl="4m"
 
 vault secrets enable transit
 vault write -f transit/keys/payments-app

--- a/payments-app/java/src/main/resources/bootstrap.yml
+++ b/payments-app/java/src/main/resources/bootstrap.yml
@@ -1,5 +1,6 @@
 server:
   port: ${SERVER_PORT:8081}
+  shutdown: graceful
 
 spring:
   application:


### PR DESCRIPTION
As part of testing, add optional configuration using SIGHUP to restart application container. Include new annotations to cache secrets and leases after initialization and render static secrets on an interval.